### PR TITLE
Fix Vercel deployment TypeScript error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "author": "",
   "license": "ISC",
   "type": "commonjs",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "dependencies": {
     "argon2": "^0.44.0",
     "cookie-parser": "^1.4.7",

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -54,7 +54,7 @@ router.post('/signup', async (req: Request, res: Response) => {
     // Hash password
     const passwordHash = await hashPassword(password);
 
-    // Create user
+    // Create user - convert string hash to Buffer for BYTEA column
     const userId = randomUUID();
     const now = new Date();
     
@@ -62,7 +62,7 @@ router.post('/signup', async (req: Request, res: Response) => {
       `INSERT INTO users (id, phone_e164, password_hash, created_at, password_updated_at)
        VALUES ($1, $2, $3, $4, $5)
        RETURNING id`,
-      [userId, phoneE164, passwordHash, now, now]
+      [userId, phoneE164, Buffer.from(passwordHash), now, now]
     );
 
     if (!newUser) {

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -1,49 +1,42 @@
-import * as argon2 from 'argon2';
+import argon2 from 'argon2';
 import { config } from '../config';
 
-export interface PasswordValidationResult {
-  isValid: boolean;
-  error?: string;
-}
-
-export function validatePasswordStrength(password: string): PasswordValidationResult {
-  if (!password || typeof password !== 'string') {
-    return {
-      isValid: false,
-      error: 'Password is required',
-    };
-  }
-
-  if (password.length < 8) {
-    return {
-      isValid: false,
-      error: 'Use 8+ characters.',
-    };
-  }
-
-  return {
-    isValid: true,
-  };
-}
-
-export async function hashPassword(password: string): Promise<Buffer> {
-  return argon2.hash(password, {
+/**
+ * Hash a password using Argon2id with configured parameters
+ */
+export async function hashPassword(password: string): Promise<string> {
+  return await argon2.hash(password, {
     type: argon2.argon2id,
     memoryCost: config.argon2.memoryMB * 1024, // Convert MB to KB
     timeCost: config.argon2.iterations,
     parallelism: config.argon2.parallelism,
-    raw: true, // Return raw buffer
   });
 }
 
-export async function verifyPassword(
-  hash: Buffer,
-  password: string
-): Promise<boolean> {
+/**
+ * Verify a password against a hash
+ */
+export async function verifyPassword(hash: string | Buffer, password: string): Promise<boolean> {
   try {
-    return await argon2.verify(hash, password);
-  } catch (error) {
-    console.error('Password verification error:', error);
+    // Handle both string and Buffer types for backward compatibility
+    const hashString = typeof hash === 'string' ? hash : hash.toString();
+    return await argon2.verify(hashString, password);
+  } catch {
     return false;
   }
+}
+
+/**
+ * Validate password meets minimum requirements
+ */
+export function validatePasswordStrength(password: string): { isValid: boolean; error?: string } {
+  if (!password || typeof password !== 'string') {
+    return { isValid: false, error: 'Password is required' };
+  }
+
+  if (password.length < 8) {
+    return { isValid: false, error: 'Use 8+ characters' };
+  }
+
+  return { isValid: true };
 }


### PR DESCRIPTION
- Changed hashPassword to return string instead of Buffer
- Updated verifyPassword to handle both string and Buffer types  
- Convert argon2 string hash to Buffer when storing in PostgreSQL
- Added Node.js >=18.0.0 engine requirement for Vercel compatibility
- Tested signup, login, and wrong password scenarios successfully